### PR TITLE
Fixed extra '>' being inserted after end tags

### DIFF
--- a/plugin/closetag.vim
+++ b/plugin/closetag.vim
@@ -241,7 +241,7 @@ fun! s:CloseTagFun()
                 if b:haveAtt == 0
                     call s:Callback (b:tagName, b:html_mode)
                 en
-                exe "normal! a</" . b:tagName . ">\<Esc>F<"
+                exe "normal! a</" . b:tagName . "\<Esc>F<"
                 start
                 retu
             en


### PR DESCRIPTION
I noticed that an extra '>' was being inserted after tags were completed. Changed line 244 to prevent this.
