### PR TITLE
Optional setting for case sensitive comparison for non-closing tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ And now if you press <kbd>&gt;</kbd> again, the content will be:
         |
     </table>
 
+The following tags will not be closed:
+
+    <area>, <base>, <br>, <col>, <command>, <embed>, <hr>, <img>, 
+    <input>, <keygen>, <link>, <meta>, <param>, <source>, <track>, <wbr>
+
 #### Install
 
 * Just put the files into ~/.vim/ or &lt;HOMEDIR&gt;\vimfiles\ (for Windows).
@@ -36,3 +41,7 @@ You can set this in your vimrc:
 
 Then after you press <kbd>&gt;</kbd> in these files, this plugin will try to close the current tag.
 
+You can set:
+
+    let g:closetag_emptyTags_caseSensitive = 1
+This will make the list of non closing tags case sensitive (e.g. `<Link>` will be closed while `<link>` won't.)

--- a/plugin/closetag.vim
+++ b/plugin/closetag.vim
@@ -26,6 +26,10 @@ if g:closetag_filenames == ""
     finish
 endif
 
+if !exists('g:closetag_emptyTags_caseSensitive')
+    let g:closetag_emptyTags_caseSensitive = 0
+endif
+
 exec "au BufNewFile,Bufread " . g:closetag_filenames . " inoremap <silent> <buffer> > ><Esc>:call <SID>CloseTagFun()<Cr>"
 
 " Script rgular expresion used. Documents those nasty criters      {{{1
@@ -87,6 +91,16 @@ fun! s:hasAtt()
             let b:haveAtt = 1
         en
     en
+endf
+
+" TagShouldBeEmpty() should the tag be treated as an non closing) tag?   {{{1
+" check the current tag with the set of tags defined in b:emptyTags 
+" closetag_emptyTags_caseSensitive defines if the check is case sensitive
+fun! s:TagShouldBeEmpty()
+	if g:closetag_emptyTags_caseSensitive == 1
+		return b:tagName =~#  b:emptyTags
+	en
+	return b:tagName =~?  b:emptyTags
 endf
 
 " TagUnderCursor()  Is there a tag under the cursor?               {{{1
@@ -219,7 +233,7 @@ fun! s:CloseTagFun()
     elseif s:TagUnderCursor()
         if b:firstWasEndTag == 0
             exe "silent normal! />\<Cr>"
-            if b:html_mode && b:tagName =~?  b:emptyTags
+            if b:html_mode && s:TagShouldBeEmpty()
                 if b:haveAtt == 0
                     call s:Callback (b:tagName, b:html_mode)
                 en


### PR DESCRIPTION
This change introduces an option to do the non-closing tags case sensitive. While writing some React code I discovered my `Link` tags were not closing by this plugin.
The g:closetag_emptyTags_caseSensitive is optional and is set by default to 0, therefore a behavior of the plugin should not be changed unless one specifically sets the value to 1.

![vim-closetag-case-sensitive](https://cloud.githubusercontent.com/assets/147080/25371109/882e164a-2954-11e7-8cf7-488a68be0ce9.gif)
