### PR TITLE
Single quotes are enough for closetag_filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following tags will not be closed:
 Set in your vimrc:
 
     " filenames like *.xml, *.html, *.xhtml, ...
-    let g:closetag_filenames = "*.html,*.xhtml,*.phtml"
+    let g:closetag_filenames = '*.html,*.xhtml,*.phtml'
 
 Then after you press <kbd>&gt;</kbd> in these files, this plugin will try to close the current tag.
 


### PR DESCRIPTION
After running https://github.com/w0rp/ale I stumbled upon this improvement.