### PR TITLE
Fix error "not found : after ?" in Vim 7.2

### DIFF
--- a/plugin/closetag.vim
+++ b/plugin/closetag.vim
@@ -110,8 +110,8 @@ endf
 " closetag_emptyTags_caseSensitive defines if the check is case sensitive
 fun! s:AsEmpty()
     retu g:closetag_emptyTags_caseSensitive == 1
-                \? b:closetag_tagName =~# b:closetag_emptyTags
-                \: b:closetag_tagName =~?  b:closetag_emptyTags
+                \ ? b:closetag_tagName =~# b:closetag_emptyTags
+                \ : b:closetag_tagName =~?  b:closetag_emptyTags
 endf
 
 " Is there a tag under the cursor?


### PR DESCRIPTION
In Vim 7.2, i recived this error when type a close tag `>`