### PR TITLE
Update the closetag_regions for official filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ let g:closetag_emptyTags_caseSensitive = 1
 " Disables auto-close if not in a "valid" region (based on filetype)
 "
 let g:closetag_regions = {
-    \ 'typescript.tsx': 'jsxRegion,tsxRegion',
-    \ 'javascript.jsx': 'jsxRegion',
+    \ 'typescriptreact': 'jsxRegion,tsxRegion',
+    \ 'javascriptreact': 'jsxRegion',
     \ }
 
 " Shortcut for closing tags, default is '>'


### PR DESCRIPTION
It seems that in issue https://github.com/vim/vim/issues/4830 the convention in vim has now been to use `typescriptreact` and `javascriptreact` as the official filetypes, rather than the current ones in the README.

Popular plugins seem to be either changing over or have support for both.

**vim-jsx-typescript**: https://github.com/peitalin/vim-jsx-typescript#vim-jsx-typescript

> Changelog: filetypes were updated from typescript.tsx to typescriptreact Please set filetypes as typescriptreact, not typescript.tsx as in prior versions in your .vimrc if you have any issues

**vim-jsx-pretty**: https://github.com/MaxMEllon/vim-jsx-pretty/tree/master/after/ftplugin