### PR TITLE
Fix: React edge cases [fix #48] [partially fix #69]

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,35 @@ let g:closetag_shortcut = '>'
 let g:closetag_close_shortcut = '<leader>>'
 ```
 
+#### Note about React fragments
+
+By default, React fragments are automatically closed **only** when a React file is open.
+
+When editing a `.html` file you will get:
+
+```
+<|
+<>|
+```
+
+When editing a `.{t,j}sx` file you will get:
+```
+<|
+<>|</>
+```
+
+To override this behavior, you can set the global `g:closetag_enable_react_fragment` in your `.vimrc`:
+
+```vim
+" integer value [0|1]
+" Enables closing tags for React fragments -> <></> for all supported file types
+"
+let g:closetag_enable_react_fragment = 1
+" Disable closing tags for React fragments -> <></> for all supported file types
+"
+let g:closetag_enable_react_fragment = 0
+```
+
 #### Commands
 
 Use these commands to toggle enable/disable this function for current buffer:

--- a/ftplugin/javascript.jsx.vim
+++ b/ftplugin/javascript.jsx.vim
@@ -1,0 +1,1 @@
+let b:closetag_enable_react_fragment = get(g:, 'closetag_enable_react_fragment', 1)

--- a/ftplugin/javascriptreact.vim
+++ b/ftplugin/javascriptreact.vim
@@ -1,0 +1,1 @@
+let b:closetag_enable_react_fragment = get(g:, 'closetag_enable_react_fragment', 1)

--- a/ftplugin/typescript.tsx.vim
+++ b/ftplugin/typescript.tsx.vim
@@ -1,0 +1,1 @@
+let b:closetag_enable_react_fragment = get(g:, 'closetag_enable_react_fragment', 1)

--- a/ftplugin/typescriptreact.vim
+++ b/ftplugin/typescriptreact.vim
@@ -1,0 +1,1 @@
+let b:closetag_enable_react_fragment = get(g:, 'closetag_enable_react_fragment', 1)

--- a/plugin/closetag.vim
+++ b/plugin/closetag.vim
@@ -20,6 +20,8 @@ fun! s:Initial()
 
     call s:Declare('g:closetag_emptyTags_caseSensitive', 0)
 
+    " call s:Declare('g:closetag_enable_react_fragment', 0)
+
     call s:Declare('g:closetag_regions', {
         \ 'typescript.tsx': 'jsxRegion,tsxRegion',
         \ 'javascript.jsx': 'jsxRegion',
@@ -65,8 +67,8 @@ fun! s:Initial()
 
     " Script rgular expresion used. Documents those nasty criters
     " Don't check for quotes around attributes!!!
-    let s:ReqAttrib = '\(\(\s\|\n\)\+\([^>= \t]\+=[^>&]\+\)\(\s\|\n\)*\)\+\(\/\)\@\<!>'
-    let s:EndofName = '\($\|\s\|>\)'
+    let s:ReqAttrib = '\(\(\s\|\n\)\+\([^>= \t]\+=\([^&]\+\)\)\(\s\|\n\)*\)\+\(\/\)\@<!>'
+    let s:EndofName = '\($\|\s\|\(=\)\@<!>\)'
 endf
 
 " Define default variables
@@ -84,6 +86,7 @@ fun! s:InitBuf()
     call s:Declare('b:closetag_html_mode', 1)
     call s:Declare('b:closetag_haveAtt', 0)
     call s:Declare('b:closetag_use_xhtml', &filetype == 'xhtml' ? 1 : 0)
+    call s:Declare('b:closetag_enable_react_fragment', get(g:, 'closetag_enable_react_fragment'))
 endf
 
 fun! s:SavePos()
@@ -170,7 +173,7 @@ fun! s:FindTag()
         retu l:haveTag
     en
 
-    if search('[<>]','bW') >=0
+    if search('<\|\(=\)\@<!>','bW') >= 0
         if getline('.')[col('.')-1] == '<'
             if getline('.')[col('.')] == '/'
                 let b:closetag_firstWasEndTag = 1
@@ -201,11 +204,11 @@ fun! s:FindTag()
     let b:closetag_tagName = s:TagName(col('.') + b:closetag_firstWasEndTag)
     "echo 'Tag ' . b:closetag_tagName
 
-    "begin: gwang customization, do not work with an empty tag name
-    if b:closetag_tagName == ''
+    if !b:closetag_enable_react_fragment && b:closetag_tagName ==? ''
+        "begin: gwang customization, do not work with an empty tag name
         retu l:haveTag
+        "end: gwang customization, do not work with an empty tag name
     en
-    "end: gwang customization, do not work with an empty tag name
 
     let l:haveTag = 1
     if b:closetag_firstWasEndTag == 0
@@ -271,7 +274,7 @@ fun! s:CloseIt()
             en
         elseif s:FindTag()
             if b:closetag_firstWasEndTag == 0
-                exe "silent normal! />\<Cr>"
+                exe "silent normal! /\\(=\\)\\@<!>\<Cr>"
                 if b:closetag_html_mode && s:AsEmpty()
                     if b:closetag_haveAtt == 0
                         call s:Handler(b:closetag_tagName, b:closetag_html_mode)


### PR DESCRIPTION
- [x] Fix #48 
  - [x] This functionality was deliberately removed at some point
  - [x] To make sure things don't break, I added some `ftplugin` scripts that will only enable this behavior for JSX files by default.
  - [x] This functionality can be permanently enabled or disabled by setting the new `g:closetag_enable_react_fragment` option.
- [ ] Fix #69 (partially)
  - [x] Works when prop is an arrow function:
    ```
    <Button onClick={() => {}}|
    <Button onClick={() => {}}>|</Button>
    ```
  - [ ] **DOES NOT** work when prop has nested JSX eleemnts:
    ```
    <Button onClick={() => <Tooltip|
    <Button onClick={() => <Tooltip>|</Tooltip>                // Yay! It works for the inner element.

    <Button onClick={() => <Tooltip><span|</Tooltip>    
    <Button onClick={() => <Tooltip><span>|<span></Tooltip>    // Awesome! Still works...

    <Button onClick={() => <Tooltip><span><span></Tooltip>}|
    <Button onClick={() => <Tooltip><span><span></Tooltip>}>| // Oops, not working!
    ```

---

The issue with React is that it is way more flexible about what can be an attribute. For example, a JavaScript arrow function is perfectly valid JSX attribute:

```jsx
<button onClick={() => {}}></button>
```

This plugin is based on regexes. The current implementation deliberately stops when it finds the first `>` character in the line.

I altered them to be slightly more flexible in that regard. When looking for the closing bracket of the opened tag, we need to make sure that it is not preceded by an `=` sign, which is part of the arrow function syntax.

However, given that JSX tags can be arbitrarily nested, I am not sure it can be reduced to a [regular language](https://en.wikipedia.org/wiki/Chomsky_hierarchy), which means regexes may not be enough to parse it.

Even though Vim (and other languages) regex implementation is a bit more powerful than a canonical regex, we might need a more powerful tool such as [tree-sitter](https://github.com/tree-sitter/tree-sitter) to be able to do the job properly.