### PR TITLE
Do not leave `>` highlighted

### DIFF
--- a/plugin/closetag.vim
+++ b/plugin/closetag.vim
@@ -275,6 +275,7 @@ fun! s:CloseIt()
         elseif s:FindTag()
             if b:closetag_firstWasEndTag == 0
                 exe "silent normal! /\\(=\\)\\@<!>\<Cr>"
+                exe "silent normal! /poiqwepoiqwepoi"
                 if b:closetag_html_mode && s:AsEmpty()
                     if b:closetag_haveAtt == 0
                         call s:Handler(b:closetag_tagName, b:closetag_html_mode)


### PR DESCRIPTION
Do not leave `>` highlighted, especially after executing `:source $MYVIMRC`. This also happens (sometimes) without the latter command (for example after saving the file).

This completely fixes the issue, but maybe there is a better solution. It is sort of a starting point.